### PR TITLE
remove logger from sampler, simplify initialization

### DIFF
--- a/lib/graphql-hive.rb
+++ b/lib/graphql-hive.rb
@@ -18,7 +18,7 @@ require "graphql-hive/trace"
 require "graphql"
 
 at_exit do
-  GraphQLHive.configuration.usage_reporter.stop
+  GraphQLHive.configuration&.usage_reporter&.stop
 end
 
 module GraphQLHive

--- a/lib/graphql-hive/client.rb
+++ b/lib/graphql-hive/client.rb
@@ -32,11 +32,11 @@ module GraphQLHive
       code = response.code.to_i
       if code >= 400 && code < 500
         error_message = "Unsuccessful response: #{response.code} - #{response.message}"
-        @logger.warn("#{error_message} #{extract_error_details(response)}")
+        @logger.warn { "#{error_message} #{extract_error_details(response)}" }
       end
 
-      @logger.debug(response.inspect)
-      @logger.debug(response.body.inspect)
+      @logger.debug { response.inspect }
+      @logger.debug { response.body.inspect }
     rescue => e
       @logger.fatal("Failed to send data: #{e}")
     end

--- a/lib/graphql-hive/configuration.rb
+++ b/lib/graphql-hive/configuration.rb
@@ -50,7 +50,7 @@ module GraphQLHive
       setup_logger if @logger.nil?
       @client.logger = @logger if @client.logger.nil?
       if !@token && @enabled
-        @logger.warn("GraphQL Hive `token` is missing. Disabling Reporting.")
+        @logger.warn { "GraphQL Hive `token` is missing. Disabling Reporting." }
         @enabled = false
       end
     end

--- a/lib/graphql-hive/configuration.rb
+++ b/lib/graphql-hive/configuration.rb
@@ -17,7 +17,9 @@ module GraphQLHive
       buffer_size: 50,
       client_info: nil,
       collect_usage: true,
-      collect_usage_sampling: 1.0,
+      collect_usage_sampling: {
+        sample_rate: 1.0
+      },
       debug: false,
       enabled: true,
       endpoint: "app.graphql-hive.com",
@@ -58,10 +60,7 @@ module GraphQLHive
         buffer_size: buffer_size,
         client_info: client_info,
         client: client,
-        sampler: GraphQLHive::Sampler.new(
-          sampling_options: collect_usage_sampling,
-          logger: logger
-        ),
+        sampler: GraphQLHive::Sampler.build(options: collect_usage_sampling),
         queue: Thread::SizedQueue.new(queue_size),
         logger: logger
       )

--- a/lib/graphql-hive/processor.rb
+++ b/lib/graphql-hive/processor.rb
@@ -16,11 +16,11 @@ module GraphQLHive
         # TODO use data class for operation
         operation = op.deconstruct
         begin
-          @logger.debug("Processing operation from queue: #{operation}")
+          @logger.debug { "Processing operation from queue: #{operation}" }
           @buffer << operation if @sampler.sample?(operation)
 
           if @buffer.size >= @buffer_size
-            @logger.debug("Buffer is full, sending report")
+            @logger.debug { "Buffer is full, sending report" }
             flush_buffer
           end
         rescue => e

--- a/lib/graphql-hive/usage_reporter.rb
+++ b/lib/graphql-hive/usage_reporter.rb
@@ -19,12 +19,14 @@ module GraphQLHive
     def add_operation(operation)
       @queue.push(operation, true)
     rescue ThreadError
-      @logger.error("SizedQueue is full, discarding operation. Size: #{@queue.size}, Max: #{@queue.max}")
+      @logger.warn do
+        "SizedQueue is full, discarding operation. Size: #{@queue.size}, Max: #{@queue.max}"
+      end
     end
 
     def start
       if @thread&.alive?
-        @logger.warn("Usage reporter is already running")
+        @logger.warn { "Usage reporter is already running" }
       end
 
       # TODO consider using Fibers instead of threads because they are lighter weight

--- a/spec/graphql-hive/client_spec.rb
+++ b/spec/graphql-hive/client_spec.rb
@@ -91,7 +91,9 @@ RSpec.describe GraphQLHive::Client do
       end
 
       it "logs a warning with error details" do
-        expect(logger).to receive(:warn).with("Unsuccessful response: 400 - Bad Request { path: test1, message: Error message 1 }, { path: test2, message: Error message 2 }")
+        expect(logger).to receive(:warn) do |&block|
+          expect(block.call).to eq("Unsuccessful response: 400 - Bad Request { path: test1, message: Error message 1 }, { path: test2, message: Error message 2 }")
+        end
         client.send(:"/usage", body, :usage)
       end
 
@@ -99,7 +101,10 @@ RSpec.describe GraphQLHive::Client do
         let(:response) { instance_double(Net::HTTPClientError, body: "Invalid JSON", code: "400", message: "Bad Request") }
 
         it "logs a warning without error details" do
-          expect(logger).to receive(:warn).with("Unsuccessful response: 400 - Bad Request Could not parse response from Hive")
+          expect(logger).to receive(:warn) do |&block|
+            expect(block.call).to eq("Unsuccessful response: 400 - Bad Request Could not parse response from Hive")
+          end
+
           client.send(:"/usage", body, :usage)
         end
       end
@@ -108,7 +113,9 @@ RSpec.describe GraphQLHive::Client do
         let(:response) { instance_double(Net::HTTPClientError, body: "{}", code: "401", message: "Unauthorized") }
 
         it "logs a warning without error details" do
-          expect(logger).to receive(:warn).with("Unsuccessful response: 401 - Unauthorized ")
+          expect(logger).to receive(:warn) do |&block|
+            expect(block.call).to eq("Unsuccessful response: 401 - Unauthorized ")
+          end
           client.send(:"/usage", body, :usage)
         end
       end

--- a/spec/graphql-hive/configuration_spec.rb
+++ b/spec/graphql-hive/configuration_spec.rb
@@ -24,7 +24,7 @@ RSpec.describe GraphQLHive::Configuration do
       it "sets default values" do
         expect(config.buffer_size).to eq(50)
         expect(config.collect_usage).to be true
-        expect(config.collect_usage_sampling).to eq(1.0)
+        expect(config.collect_usage_sampling).to eq({sample_rate: 1.0})
         expect(config.debug).to be false
         expect(config.enabled).to be true
         expect(config.queue_size).to eq(1000)

--- a/spec/graphql-hive/configuration_spec.rb
+++ b/spec/graphql-hive/configuration_spec.rb
@@ -75,7 +75,9 @@ RSpec.describe GraphQLHive::Configuration do
 
       it "disables the service and logs a warning" do
         expect(config.enabled).to be false
-        expect(logger).to have_received(:warn).with(/token.*missing/)
+        expect(logger).to have_received(:warn) do |&block|
+          expect(block.call).to eq("GraphQL Hive `token` is missing. Disabling Reporting.")
+        end
       end
     end
 

--- a/spec/graphql-hive/processor_spec.rb
+++ b/spec/graphql-hive/processor_spec.rb
@@ -3,7 +3,7 @@ require "spec_helper"
 RSpec.describe GraphQLHive::Processor do
   let(:buffer_size) { 2 }
   let(:client) { instance_double("GraphQLHive::Client") }
-  let(:sampler) { instance_double("GraphQLHive::Sampler") }
+  let(:sampler) { instance_double("GraphQLHive::BasicSampler") }
   let(:queue) { instance_double("Thread::SizedQueue") }
   let(:logger) { instance_double("Logger") }
   let(:query) do

--- a/spec/graphql-hive/sampler/basic_sampler_spec.rb
+++ b/spec/graphql-hive/sampler/basic_sampler_spec.rb
@@ -3,7 +3,15 @@
 require "spec_helper"
 
 RSpec.describe GraphQLHive::Sampling::BasicSampler do
-  let(:sampler_instance) { described_class.new(sample_rate, at_least_once, key_generator) }
+  let(:sampler_instance) do
+    described_class.new(
+      options: {
+        sample_rate: sample_rate,
+        at_least_once: at_least_once,
+        key_generator: key_generator
+      }
+    )
+  end
   let(:sample_rate) { 0 }
   let(:at_least_once) { false }
   let(:key_generator) { nil }
@@ -11,6 +19,21 @@ RSpec.describe GraphQLHive::Sampling::BasicSampler do
   describe "#initialize" do
     it "sets the sample rate" do
       expect(sampler_instance.instance_variable_get(:@sample_rate)).to eq(0)
+    end
+
+    context "when the sample_rate is a string" do
+      let(:sample_rate) { "0.1" }
+      it "converts the sample rate to a float" do
+        expect(sampler_instance.instance_variable_get(:@sample_rate)).to eq(0.1)
+      end
+    end
+
+    context "when the sample_rate is nil" do
+      let(:sample_rate) { nil }
+
+      it "sets the sample rate to 1" do
+        expect(sampler_instance.instance_variable_get(:@sample_rate)).to eq(1)
+      end
     end
   end
 

--- a/spec/graphql-hive/sampler/dynamic_sampler_spec.rb
+++ b/spec/graphql-hive/sampler/dynamic_sampler_spec.rb
@@ -3,7 +3,15 @@
 require "spec_helper"
 
 RSpec.describe GraphQLHive::Sampling::DynamicSampler do
-  let(:sampler_instance) { described_class.new(sampler, at_least_once, key_generator) }
+  let(:sampler_instance) do
+    described_class.new(
+      options: {
+        sampler: sampler,
+        at_least_once: at_least_once,
+        key_generator: key_generator
+      }
+    )
+  end
   let(:sampler) { proc { |_sample_context| 0 } }
   let(:at_least_once) { false }
   let(:key_generator) { nil }

--- a/spec/graphql-hive/sampler_spec.rb
+++ b/spec/graphql-hive/sampler_spec.rb
@@ -3,36 +3,30 @@
 require "spec_helper"
 
 RSpec.describe GraphQLHive::Sampler do
-  let(:sampler_instance) { described_class.new(sampling_options: sampling_options, logger: logger) }
+  let(:sampler_instance) do
+    described_class.build(
+      options: sampling_options
+    )
+  end
   let(:sampling_options) { nil }
-  let(:logger) { instance_double("Logger") }
 
   describe "#initialize" do
     it "creates a basic sampler" do
-      expect(sampler_instance.instance_variable_get(:@sampler)).to be_an_instance_of(GraphQLHive::Sampling::BasicSampler)
+      expect(sampler_instance).to be_an_instance_of(GraphQLHive::Sampling::BasicSampler)
     end
 
     context "when provided a sampling rate" do
       let(:sampling_options) { {sample_rate: 0.5} }
 
       it "creates a basic sampler" do
-        expect(sampler_instance.instance_variable_get(:@sampler)).to be_an_instance_of(GraphQLHive::Sampling::BasicSampler)
+        expect(sampler_instance).to be_an_instance_of(GraphQLHive::Sampling::BasicSampler)
       end
 
       context "using the deprecated field" do
         let(:sampling_options) { 1 }
 
-        before do
-          allow(logger).to receive(:warn)
-        end
-
         it "creates a basic sampler" do
-          expect(sampler_instance.instance_variable_get(:@sampler)).to be_an_instance_of(GraphQLHive::Sampling::BasicSampler)
-        end
-
-        it "logs a warning" do
-          sampler_instance
-          expect(logger).to have_received(:warn)
+          expect(sampler_instance).to be_an_instance_of(GraphQLHive::Sampling::BasicSampler)
         end
       end
     end
@@ -41,7 +35,7 @@ RSpec.describe GraphQLHive::Sampler do
       let(:sampling_options) { {sampler: proc {}} }
 
       it "creates a dynamic sampler" do
-        expect(sampler_instance.instance_variable_get(:@sampler)).to be_an_instance_of(GraphQLHive::Sampling::DynamicSampler)
+        expect(sampler_instance).to be_an_instance_of(GraphQLHive::Sampling::DynamicSampler)
       end
     end
   end

--- a/spec/graphql-hive/schema_reporter_spec.rb
+++ b/spec/graphql-hive/schema_reporter_spec.rb
@@ -9,7 +9,7 @@ RSpec.describe GraphQLHive::SchemaReporter do
       force: true
     }
   end
-  let(:config) { instance_double(GraphQLHive::Configuration) }
+  let(:config) { instance_double(GraphQLHive::Configuration, :logger= => nil, :logger => nil) }
   let(:client) { instance_double(GraphQLHive::Client) }
 
   before do

--- a/spec/graphql-hive/trace_spec.rb
+++ b/spec/graphql-hive/trace_spec.rb
@@ -24,7 +24,6 @@ RSpec.describe GraphQLHive::Trace do
   before do
     GraphQLHive.configure do |config|
       config.token = "test-token"
-      config.logger = Logger.new(nil)
     end
     allow(GraphQLHive::Tracing).to receive(:new).and_return(hive_instance)
   end
@@ -56,7 +55,6 @@ RSpec.describe GraphQLHive::Trace do
       before do
         GraphQLHive.configure do |config|
           config.token = "test-token"
-          config.logger = Logger.new(nil)
           config.collect_usage = false
         end
       end

--- a/spec/graphql-hive/tracing_spec.rb
+++ b/spec/graphql-hive/tracing_spec.rb
@@ -24,10 +24,6 @@ RSpec.describe GraphQLHive::Tracing do
     allow(usage_reporter).to receive(:stop)
   end
 
-  after do
-    Singleton.__init__(described_class)
-  end
-
   describe "#trace" do
     let(:queries) { ["query { user { id } }"] }
     let(:results) { [{"data" => {"user" => {"id" => 1}}}] }

--- a/spec/graphql-hive/usage_reporter_spec.rb
+++ b/spec/graphql-hive/usage_reporter_spec.rb
@@ -39,12 +39,14 @@ RSpec.describe GraphQLHive::UsageReporter do
     context "when queue is full" do
       before do
         allow(queue).to receive(:push).and_raise(ThreadError)
-        allow(logger).to receive(:error)
+        allow(logger).to receive(:warn).and_yield
       end
 
       it "logs error" do
         reporter.add_operation(operation)
-        expect(logger).to have_received(:error).with("SizedQueue is full, discarding operation. Size: 5, Max: 10")
+        expect(logger).to have_received(:warn) do |&block|
+          expect(block.call).to eq("SizedQueue is full, discarding operation. Size: 5, Max: 10")
+        end
       end
     end
   end
@@ -84,7 +86,9 @@ RSpec.describe GraphQLHive::UsageReporter do
     context "when thread is already alive" do
       it "logs warning" do
         reporter.start
-        expect(logger).to have_received(:warn).with("Usage reporter is already running").once
+        expect(logger).to have_received(:warn) do |&block|
+          expect(block.call).to eq("Usage reporter is already running")
+        end
       end
     end
   end


### PR DESCRIPTION
It is possible that the sampler gets called before the logger is initialized. I think we can remove this deprecation warning and allow people to pass an integer or a configuration hash.

This pr does a small refactor on how we init the sampler to remove logging and make some of the logic a little easier to follow with early returns. 